### PR TITLE
Keyboard navigation through the left-side tree

### DIFF
--- a/src/Codex.Web/Content/results.css
+++ b/src/Codex.Web/Content/results.css
@@ -61,6 +61,14 @@
     background-color: #d4edff;
 }
 
+.resultGroupHeader.selectedResult {
+    background-color: #d4edff; /* same as .resultGroupHeader:hover*/
+    border-color: #744482;
+    border-width: 1px 3px 1px 1px;
+    border-style: solid;
+    padding: 5px 3px 5px 27px; /* acommodate .resultGroupHeader's padding for extra border */
+}
+
 .resultGroupAssemblyName {
     font-size: larger;
     font-weight: bold;
@@ -82,10 +90,16 @@
     cursor: pointer;
 }
 
-    .resultItem:hover {
-        background-color: #f6f6f6;
-    }
+.resultItem:hover {
+    background-color: #f6f6f6;
+}
 
+.resultItem.selectedResult {
+    background-color: #f6f6f6; /* same as .resultItem:hover*/
+    border-color: #744482;
+    border-right-width: 3px;
+    border-right-style: solid;
+}
 
 .resultKind {
     display: inline;

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -42,26 +42,29 @@ function ensureSearchBox() {
     searchBox.focus();
 
     searchBox.onkeyup = function () {
+        if (event && event.keyCode == 13) { // enter
+            lastSearchString = "";
+            onSearchChange();
+        }
+    }
+    // onkeydown supports repeating when user holds the button
+    searchBox.onkeydown = function () {
         if (event) {
             switch (event.keyCode) {
-                case 13: // enter
-                    lastSearchString = "";
-                    onSearchChange();
-                    break;
                 case 38: // up
                     if (event.ctrlKey) {
                         collapseResult();
                     } else {
                         selectPreviousResult();
                     }
-                    break;
+                    return false; // cancel the event so the caret doesn't move
                 case 40: // down
                     if (event.ctrlKey) {
                         expandResult();
                     } else {
                         selectNextResult();
                     }
-                    break;
+                    return false; // cancel the event so the caret doesn't move
                 default:
                     break;
             }

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -194,7 +194,7 @@ function selectPreviousResult() {
         selectedUIElement.removeClass("selectedResult");
     }
 
-    if (selectedResult == null && selectedResult.length) {
+    if (selectedResult == null || !selectedResult.length) {
         // Last result
         selectedResultGroup = selectedResultGroup.prev(".resultGroup");
         if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -182,7 +182,11 @@ function selectNextResult() {
             }
         }
     }
-    selectedUIElement.addClass("selectedResult");
+    if (selectedUIElement != null && selectedUIElement.length) {
+        // Select and scroll to the element
+        selectedUIElement.addClass("selectedResult");
+        selectedUIElement[0].scrollIntoViewIfNeeded();
+    }
 }
 
 function selectPreviousResult() {
@@ -225,11 +229,16 @@ function selectPreviousResult() {
             }
             else {
                 // We've reached the beginning
+                $("#leftPane").scrollTop(0); // scroll to the very top
                 return;
             }
         }
     }
-    selectedUIElement.addClass("selectedResult");
+    if (selectedUIElement != null && selectedUIElement.length) {
+        // Select and scroll to the element
+        selectedUIElement.addClass("selectedResult");
+        selectedUIElement[0].scrollIntoViewIfNeeded();
+    }
 }
 
 function LoadSearchCore(searchText) {

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -39,9 +39,15 @@ function ensureSearchBox() {
     searchBox.focus();
 
     searchBox.onkeyup = function () {
-        if (event && event.keyCode == 13) {
-            lastSearchString = "";
-            onSearchChange();
+        if (event) {
+            switch (event.keyCode) {
+                case 13:
+                    lastSearchString = "";
+                    onSearchChange();
+                    break;
+                default:
+                    break;
+            }
         }
     };
 

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -2,6 +2,9 @@
 var lastSearchString = "";
 var searchTimerID = -1;
 var searchBox = null;
+var selectedResultGroup = null; // model
+var selectedResult = null;      // model
+var selectedUIElement = null;   // presentation
 
 function onBodyLoad() {
 
@@ -41,9 +44,23 @@ function ensureSearchBox() {
     searchBox.onkeyup = function () {
         if (event) {
             switch (event.keyCode) {
-                case 13:
+                case 13: // enter
                     lastSearchString = "";
                     onSearchChange();
+                    break;
+                case 38: // up
+                    if (event.ctrlKey) {
+                        collapseResult();
+                    } else {
+                        selectPreviousResult();
+                    }
+                    break;
+                case 40: // down
+                    if (event.ctrlKey) {
+                        expandResult();
+                    } else {
+                        selectNextResult();
+                    }
                     break;
                 default:
                     break;
@@ -60,6 +77,7 @@ function onSearchChange() {
     if (lastSearchString && lastSearchString == searchBox.value) {
         return;
     }
+    resetSelectedResult();
 
     if (searchBox.value.length > 2) {
         if (searchTimerID == -1) {
@@ -69,6 +87,157 @@ function onSearchChange() {
         setLeftPane("<div class='note'>Enter at least 3 characters.</div>");
         lastSearchString = searchBox.value;
     }
+}
+
+// Called when a new search happens and result list is reset
+function resetSelectedResult() {
+    selectedResultGroup = null;
+    selectedResult = null;
+    if (selectedUIElement != null) {
+        selectedUIElement.removeClass("selectedResult");
+        selectedUIElement = null;
+    }
+}
+
+// This function depends on HTML defined in 
+function expandResult() {
+    if (selectedUIElement == null) {
+        return;
+    }
+    if (selectedUIElement.is('.resultItem')) {
+        selectedUIElement.parent().trigger("click");
+    } else if (selectedUIElement.is('.resultGroupHeader')) {
+        if (selectedUIElement.next("div").css("display") == "none") {
+            selectedUIElement.trigger("click");
+        }
+    }
+}
+
+function collapseResult() {
+    if (selectedUIElement == null) {
+        return;
+    }
+    if (selectedUIElement.is('.resultItem')) {
+        selectedUIElement.removeClass("selectedResult");
+        selectedResult = null;
+        selectedResultGroup = selectedUIElement.parent().parent().parent().first();
+        selectedUIElement = selectedResultGroup.children('.resultGroupHeader')
+        selectedUIElement.trigger("click");
+        selectedUIElement.addClass("selectedResult");
+    } else if (selectedUIElement.is('.resultGroupHeader')) {
+        if (selectedUIElement.next("div").css("display") != "none") {
+            selectedUIElement.trigger("click");
+        }
+    }
+}
+
+function selectNextResult() {
+    if (selectedUIElement != null) {
+        selectedUIElement.removeClass("selectedResult");
+    }
+
+    if (selectedResultGroup == null) {
+        console.log("1st group");
+        // Select first group
+        selectedResultGroup = $(".resultGroup").first();
+        selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
+    }
+    else {
+        if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {
+            // go ahead with the next result
+            if (selectedResult == null) {
+                console.log("1st result");
+                var resultContainer = selectedResultGroup.children().not(".resultGroupHeader").first();
+                var resultLink = resultContainer.children("a").first();
+                selectedResult = resultLink.children(".resultItem").first();
+                selectedUIElement = selectedResult;
+            }
+            else {
+                var resultLink = selectedResult.parent().next();
+                if (resultLink.is('a')) {
+                    console.log("Next result");
+                    selectedResult = resultLink.children(".resultItem").first();
+                    selectedUIElement = selectedResult;
+                }
+                else { // There are no more siblings. Go to the next group
+                    console.log("Next group");
+                    selectedResult = null; // so that we try to go back to a result
+                    selectedResultGroup = selectedResultGroup.next(".resultGroup");
+                    if (selectedResultGroup.is("div")) {
+                        selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
+                    }
+                    else {
+                        console.log("You've reached the end.");
+                        return;
+                    }
+                }
+            }
+        }
+        else {
+            // select the next group instead
+            console.log("Next group");
+            selectedResult = null; // so that we try to go back to a result
+            selectedResultGroup = selectedResultGroup.next(".resultGroup");
+            if (selectedResultGroup.is("div")) {
+                selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
+            }
+            else {
+                console.log("You've reached the end.");
+                return;
+            }
+        }
+    }
+    selectedUIElement.addClass("selectedResult");
+}
+
+function selectPreviousResult() {
+    if (selectedUIElement != null) {
+        selectedUIElement.removeClass("selectedResult");
+    }
+
+    if (selectedResult == null) {
+        console.log("last result");
+        selectedResultGroup = selectedResultGroup.prev(".resultGroup");
+        if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {
+            if (selectedResultGroup.is("div")) {
+                var resultContainer = selectedResultGroup.children().not(".resultGroupHeader").first();
+                var resultLink = resultContainer.children("a").last();
+                selectedResult = resultLink.children(".resultItem").first();
+                selectedUIElement = selectedResult;
+            }
+            else {
+                console.log("You've reached the beginning.");
+                return;
+            }
+        }
+        else {
+            // The group we would have went to is collapsed. go to its header
+            console.log("group is collapsed");
+            selectedResult = null;
+            selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
+        }
+    }
+    else {
+        var resultLink = selectedResult.parent().prev();
+        if (resultLink.is('a')) {
+            console.log("previous result");
+            selectedResult = resultLink.children(".resultItem").first();
+            selectedUIElement = selectedResult;
+        }
+        else { // There are no more siblings. Go to the previous group
+            console.log("This group's header");
+            //selectedResultGroup = selectedResult selectedResultGroup.prev(".resultGroup");
+            selectedResult = null; // so that we try to go back to a result
+            if (selectedResultGroup.is("div")) {
+                selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
+            }
+            else {
+                console.log("You've reached the beginning.");
+                return;
+            }
+        }
+    }
+    selectedUIElement.addClass("selectedResult");
 }
 
 function LoadSearchCore(searchText) {

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -139,13 +139,13 @@ function selectNextResult() {
         selectedUIElement.removeClass("selectedResult");
     }
 
-    if (selectedResultGroup == null) { // Nothing is selected. Select the first group.
+    if (selectedResultGroup == null || !selectedResultGroup.length) { // Nothing is selected. Select the first group.
         selectedResultGroup = $(".resultGroup").first();
         selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
     }
     else {
         if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {
-            if (selectedResult == null) { // Select the first result
+            if (selectedResult == null || !selectedResult.length) { // Select the first result
                 var resultContainer = selectedResultGroup.children().not(".resultGroupHeader").first();
                 var resultLink = resultContainer.children("a").first();
                 selectedResult = resultLink.children(".resultItem").first();
@@ -194,7 +194,7 @@ function selectPreviousResult() {
         selectedUIElement.removeClass("selectedResult");
     }
 
-    if (selectedResult == null) {
+    if (selectedResult == null && selectedResult.length) {
         // Last result
         selectedResultGroup = selectedResultGroup.prev(".resultGroup");
         if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {
@@ -206,6 +206,7 @@ function selectPreviousResult() {
             }
             else {
                 // We've reached the beginning of the list
+                $("#leftPane").scrollTop(0); // scroll to the very top
                 return;
             }
         }

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -103,7 +103,7 @@ function resetSelectedResult() {
 }
 
 function expandResult() {
-    if (selectedUIElement == null) {
+    if (selectedUIElement == null || !selectedUIElement.length) {
         return;
     }
     if (selectedUIElement.is('.resultItem')) { // Selected item is a single result
@@ -116,7 +116,7 @@ function expandResult() {
 }
 
 function collapseResult() {
-    if (selectedUIElement == null) {
+    if (selectedUIElement == null || !selectedUIElement.length) {
         return;
     }
     if (selectedUIElement.is('.resultItem')) { // Selected item is a single result
@@ -165,6 +165,7 @@ function selectNextResult() {
                     }
                     else {
                         // We've reached the end of the list
+                        selectedUIElement = null;
                         return;
                     }
                 }
@@ -178,6 +179,7 @@ function selectNextResult() {
             }
             else {
                 // We've reached the end of the list
+                selectedUIElement = null;
                 return;
             }
         }
@@ -206,6 +208,8 @@ function selectPreviousResult() {
             }
             else {
                 // We've reached the beginning of the list
+                selectedResult = null;
+                selectedUIElement = null;
                 $("#leftPane").scrollTop(0); // scroll to the very top
                 return;
             }
@@ -230,6 +234,7 @@ function selectPreviousResult() {
             }
             else {
                 // We've reached the beginning
+                selectedUIElement = null;
                 $("#leftPane").scrollTop(0); // scroll to the very top
                 return;
             }

--- a/src/Codex.Web/Scripts/search.js
+++ b/src/Codex.Web/Scripts/search.js
@@ -99,14 +99,13 @@ function resetSelectedResult() {
     }
 }
 
-// This function depends on HTML defined in 
 function expandResult() {
     if (selectedUIElement == null) {
         return;
     }
-    if (selectedUIElement.is('.resultItem')) {
+    if (selectedUIElement.is('.resultItem')) { // Selected item is a single result
         selectedUIElement.parent().trigger("click");
-    } else if (selectedUIElement.is('.resultGroupHeader')) {
+    } else if (selectedUIElement.is('.resultGroupHeader')) { // Selected item is a group
         if (selectedUIElement.next("div").css("display") == "none") {
             selectedUIElement.trigger("click");
         }
@@ -117,14 +116,15 @@ function collapseResult() {
     if (selectedUIElement == null) {
         return;
     }
-    if (selectedUIElement.is('.resultItem')) {
+    if (selectedUIElement.is('.resultItem')) { // Selected item is a single result
+        // Select the parent group and collapse it
         selectedUIElement.removeClass("selectedResult");
         selectedResult = null;
         selectedResultGroup = selectedUIElement.parent().parent().parent().first();
         selectedUIElement = selectedResultGroup.children('.resultGroupHeader')
         selectedUIElement.trigger("click");
         selectedUIElement.addClass("selectedResult");
-    } else if (selectedUIElement.is('.resultGroupHeader')) {
+    } else if (selectedUIElement.is('.resultGroupHeader')) { // Selected item is a group
         if (selectedUIElement.next("div").css("display") != "none") {
             selectedUIElement.trigger("click");
         }
@@ -132,57 +132,49 @@ function collapseResult() {
 }
 
 function selectNextResult() {
-    if (selectedUIElement != null) {
+    if (selectedUIElement != null) { // Deselect currently selected element
         selectedUIElement.removeClass("selectedResult");
     }
 
-    if (selectedResultGroup == null) {
-        console.log("1st group");
-        // Select first group
+    if (selectedResultGroup == null) { // Nothing is selected. Select the first group.
         selectedResultGroup = $(".resultGroup").first();
         selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
     }
     else {
         if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {
-            // go ahead with the next result
-            if (selectedResult == null) {
-                console.log("1st result");
+            if (selectedResult == null) { // Select the first result
                 var resultContainer = selectedResultGroup.children().not(".resultGroupHeader").first();
                 var resultLink = resultContainer.children("a").first();
                 selectedResult = resultLink.children(".resultItem").first();
                 selectedUIElement = selectedResult;
             }
-            else {
+            else { // Select the next result
                 var resultLink = selectedResult.parent().next();
                 if (resultLink.is('a')) {
-                    console.log("Next result");
                     selectedResult = resultLink.children(".resultItem").first();
                     selectedUIElement = selectedResult;
                 }
                 else { // There are no more siblings. Go to the next group
-                    console.log("Next group");
-                    selectedResult = null; // so that we try to go back to a result
+                    selectedResult = null;
                     selectedResultGroup = selectedResultGroup.next(".resultGroup");
                     if (selectedResultGroup.is("div")) {
                         selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
                     }
                     else {
-                        console.log("You've reached the end.");
+                        // We've reached the end of the list
                         return;
                     }
                 }
             }
         }
-        else {
-            // select the next group instead
-            console.log("Next group");
+        else { // Select the next group
             selectedResult = null; // so that we try to go back to a result
             selectedResultGroup = selectedResultGroup.next(".resultGroup");
             if (selectedResultGroup.is("div")) {
                 selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
             }
             else {
-                console.log("You've reached the end.");
+                // We've reached the end of the list
                 return;
             }
         }
@@ -196,7 +188,7 @@ function selectPreviousResult() {
     }
 
     if (selectedResult == null) {
-        console.log("last result");
+        // Last result
         selectedResultGroup = selectedResultGroup.prev(".resultGroup");
         if (selectedResultGroup.children().not(".resultGroupHeader").first().css("display") != "none") {
             if (selectedResultGroup.is("div")) {
@@ -206,13 +198,12 @@ function selectPreviousResult() {
                 selectedUIElement = selectedResult;
             }
             else {
-                console.log("You've reached the beginning.");
+                // We've reached the beginning of the list
                 return;
             }
         }
         else {
             // The group we would have went to is collapsed. go to its header
-            console.log("group is collapsed");
             selectedResult = null;
             selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
         }
@@ -220,19 +211,17 @@ function selectPreviousResult() {
     else {
         var resultLink = selectedResult.parent().prev();
         if (resultLink.is('a')) {
-            console.log("previous result");
+            // Previous result
             selectedResult = resultLink.children(".resultItem").first();
             selectedUIElement = selectedResult;
         }
         else { // There are no more siblings. Go to the previous group
-            console.log("This group's header");
-            //selectedResultGroup = selectedResult selectedResultGroup.prev(".resultGroup");
             selectedResult = null; // so that we try to go back to a result
             if (selectedResultGroup.is("div")) {
                 selectedUIElement = selectedResultGroup.children(".resultGroupHeader").first();
             }
             else {
-                console.log("You've reached the beginning.");
+                // We've reached the beginning
                 return;
             }
         }


### PR DESCRIPTION
This PR adds keyboard navigation functionality to the left-side tree
When focus is in the search box,
* `Down arrow` selects next item, either a leaf node or group header
* `Up arrow` selects previous item, either a leaf node or group header
* `Ctrl+down` expands the group, if collapsed group header is selected
* `Ctrl+up` collapses the group, whether user selected leaf node or group header 

Selected item is automatically scrolled into view, if necessary

For example, to get this screenshot, I typed `code` `down` `ctrl up` `down` `down`
![2017-07-25_20h30_40](https://user-images.githubusercontent.com/1673956/28603334-4125a04e-7178-11e7-98e1-f3322233df50.png)
