### PR TITLE
Delete Microsoft.Build.* assemblies from build output and use Microsoft.Build.Locator

### DIFF
--- a/src/Codex/Codex.csproj
+++ b/src/Codex/Codex.csproj
@@ -1,10 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props" Condition="Exists('..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props')" />
   <PropertyGroup>
     <SrcRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Common.props))</SrcRoot>
     <ProjectGuid>{18F9B5DD-54B9-49F3-B788-8A066314BB98}</ProjectGuid>
     <AssemblyName>Codex</AssemblyName>
     <RootNamespace>Codex</RootNamespace>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -25,6 +28,9 @@
     <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Build.Framework.15.1.1012\lib\net46\Microsoft.Build.Framework.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Build.Locator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9dff12846e04bfbd, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Build.Locator.1.0.13\lib\net46\Microsoft.Build.Locator.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Build.Tasks.Core.15.1.1012\lib\net46\Microsoft.Build.Tasks.Core.dll</HintPath>
@@ -202,7 +208,9 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
@@ -210,4 +218,19 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SrcRoot)\Common.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets'))" />
+  </Target>
+  <Import Project="..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets" Condition="Exists('..\..\packages\Microsoft.Build.Locator.1.0.13\build\Microsoft.Build.Locator.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>del "$(TargetDir)Microsoft.Build.dll"
+del "$(TargetDir)Microsoft.Build.Framework.dll"
+del "$(TargetDir)Microsoft.Build.Tasks.Core.dll"
+del "$(TargetDir)Microsoft.Build.Utilties.Core.dll"
+</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/Codex/Program.cs
+++ b/src/Codex/Program.cs
@@ -15,6 +15,7 @@ using Codex.Import;
 using Codex.Logging;
 using Codex.ObjectModel;
 using Codex.Storage;
+using Microsoft.Build.Locator;
 using Mono.Options;
 
 namespace Codex.Application
@@ -66,6 +67,8 @@ namespace Codex.Application
             if (string.IsNullOrEmpty(rootDirectory)) throw new ArgumentException("Solution path is missing. Use -p to provide it.");
             if (string.IsNullOrEmpty(repoName)) throw new ArgumentException("Repository name is missing. Use -n to provide it.");
             if (string.IsNullOrEmpty(elasticSearchServer)) throw new ArgumentException("Elastic Search server URL is missing. Use -es to provide it.");
+
+            MSBuildLocator.RegisterDefaults();
 
             try
             {

--- a/src/Codex/app.config
+++ b/src/Codex/app.config
@@ -34,6 +34,18 @@
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Build.Utilities.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Codex/packages.config
+++ b/src/Codex/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="ManagedEsent" version="1.9.4" targetFramework="net46" />
   <package id="Microsoft.Build.Framework" version="15.1.1012" targetFramework="net46" />
+  <package id="Microsoft.Build.Locator" version="1.0.13" targetFramework="net46" />
   <package id="Microsoft.Build.Tasks.Core" version="15.1.1012" targetFramework="net46" />
   <package id="Microsoft.Build.Utilities.Core" version="15.1.1012" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net46" />


### PR DESCRIPTION
Fixes #102

Codex directly and indirectly references the `Microsoft.Build`, `Microsoft.Build.Framework`, `Microsoft.Build.Tasks.Core` and `Microsoft.Build.Utilities.Core` packages, causing those assemblies to be copied to the build output. Then, when Codex uses the MSBuild APIs it loads these specific `Microsoft.Build*` assemblies, but they aren't compatible with the tasks and targets in the MSBuild toolset installed with more recent versions of VS 2017. So, bad things happen. :smile:

This change removes the offending assemblies from the build output as a custom build step. In the future, if Codex is converted over to using `<PackageReference/>` rather than `packages.config` the custom build step can be removed and the package references for those MSBuild packages should have the `ExcludeAssets="Runtime"` and `PrivateAssets="All"` attributes included on them to ensure they don't get copied.

With the `Microsoft.Build.*` assemblies removed, Codex needs to find them somewhere. So, this change adds the `Microsoft.Build.Locator` package and along with a call to `MSBuildLocator.RegisterDefaults()`. This installs an `AppDomain.AssemblyResolve` that will resolve the `Microsoft.Build.*` assemblies from the default instance of VS 2017 that is found on the current machine. So, the versions of those assemblies that are loaded will be compatible with the tasks and targets in the instance of VS.